### PR TITLE
nombre funcion 'fn' refactorizado a 'fnctn'

### DIFF
--- a/classes/Programa.php
+++ b/classes/Programa.php
@@ -23,7 +23,7 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-use function Latitude\QueryBuilder\{alias, on, fn, param};
+use function Latitude\QueryBuilder\{alias, on, fnctn, param};
 
 defined('MOODLE_INTERNAL') || die;
 require_once(__DIR__ . '/../../../config.php');
@@ -66,7 +66,7 @@ class Programa extends BaseDAO {
             ->select(
                 'programa.'.Programa::ID,
                 alias(
-                    fn(
+                    fnctn(
                         'concat_ws',
                         param(' - '),
                         'programa.'.Programa::NOMBRE,

--- a/vendor/latitude/latitude/src/functions.php
+++ b/vendor/latitude/latitude/src/functions.php
@@ -13,7 +13,7 @@ function alias($field, string $alias): ExpressionInterface
     return express('%s AS %s', identify($field), identify($alias));
 }
 
-function fn(string $function, ...$replacements): ExpressionInterface
+function fnctn(string $function, ...$replacements): ExpressionInterface
 {
     return express("$function(%s)", listing(identifyAll($replacements)));
 }

--- a/vendor/latitude/latitude/tests/Issues/ParamsInsideFunctionsTest.php
+++ b/vendor/latitude/latitude/tests/Issues/ParamsInsideFunctionsTest.php
@@ -4,7 +4,7 @@ namespace Latitude\QueryBuilder\Issues;
 
 use Latitude\QueryBuilder\TestCase;
 
-use function Latitude\QueryBuilder\fn;
+use function Latitude\QueryBuilder\fnctn;
 use function Latitude\QueryBuilder\param;
 
 /**
@@ -14,7 +14,7 @@ class ParamsInsideFunctionsTest extends TestCase
 {
     public function testFnColumns()
     {
-        $expr = fn('COUNT', 'id');
+        $expr = fnctn('COUNT', 'id');
 
         $this->assertSql('COUNT(id)', $expr);
         $this->assertParams([], $expr);
@@ -23,7 +23,7 @@ class ParamsInsideFunctionsTest extends TestCase
 
     public function testFnParams()
     {
-        $expr = fn('POINT', param(1), param(2));
+        $expr = fnctn('POINT', param(1), param(2));
 
         $this->assertSql('POINT(?, ?)', $expr);
         $this->assertParams([1, 2], $expr);

--- a/vendor/latitude/latitude/tests/Query/SelectTest.php
+++ b/vendor/latitude/latitude/tests/Query/SelectTest.php
@@ -6,7 +6,7 @@ use Latitude\QueryBuilder\TestCase;
 
 use function Latitude\QueryBuilder\alias;
 use function Latitude\QueryBuilder\field;
-use function Latitude\QueryBuilder\fn;
+use function Latitude\QueryBuilder\fnctn;
 use function Latitude\QueryBuilder\on;
 
 class SelectTest extends TestCase
@@ -167,7 +167,7 @@ class SelectTest extends TestCase
     {
         $select = $this->factory
             ->select(
-                alias(fn('COUNT', 'id'), 'total')
+                alias(fnctn('COUNT', 'id'), 'total')
             )
             ->from('employees')
             ->groupBy('department');
@@ -187,7 +187,7 @@ class SelectTest extends TestCase
         $select = $this->factory
             ->select(
                 'department',
-                alias($sum = fn('SUM', 'salary'), 'total')
+                alias($sum = fnctn('SUM', 'salary'), 'total')
             )
             ->from('employees')
             ->groupBy('department')
@@ -222,7 +222,7 @@ class SelectTest extends TestCase
             ->select(
                 'u.id',
                 'u.username',
-                alias(fn('COUNT', 'l.id'), 'total')
+                alias(fnctn('COUNT', 'l.id'), 'total')
             )
             ->from(alias('users', 'u'))
             ->join(alias('logins', 'l'), on('u.id', 'l.user_id'))


### PR DESCRIPTION
Se refactorizó el nombre del la función y se comprobó que no se usara la keyword en ningún otro lado, buscando "fn" en todos los archivos *.php